### PR TITLE
Fix sqrt(2) precision, add pre-coregistration, and correct variogram plotting in uncertainty propagation

### DIFF
--- a/tests/test_uncertainty/test_uncertainty_notebook.py
+++ b/tests/test_uncertainty/test_uncertainty_notebook.py
@@ -1,0 +1,203 @@
+"""
+Tests for the elevation-uncertainty module fixes, on the Longyearbyen sample data:
+  1. the sqrt(2) "same precision" correction (Hugonnet et al., 2022, Eq. 7-8),
+  2. pre-coregistration before inferring the error structure,
+  3. correct variogram plotting via the public variogram model function.
+
+Cropped sample data (``get_path_test``) and a small ``nsim`` are used for CI speed.
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from typing import Any, Callable
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import xdem
+from xdem import coreg
+from xdem.dem import DEM
+from xdem.uncertainty.uncertainty import _infer_uncertainty, _propag_uncertainty_coreg
+
+SEED = 42
+
+
+def _finite_array(elev: object) -> np.ndarray:
+    """Return a 1D float array of values from a Raster or PointCloud error field (masked -> NaN)."""
+    data = elev.data  # type: ignore[attr-defined]
+    if np.ma.isMaskedArray(data):
+        arr = data.filled(np.nan)
+    else:
+        arr = np.asarray(data, dtype=float)
+    return np.asarray(arr, dtype=float).ravel()
+
+
+def _load_dems() -> tuple[DEM, DEM]:
+    fn_ref = xdem.examples.get_path_test("longyearbyen_ref_dem")
+    fn_tba = xdem.examples.get_path_test("longyearbyen_tba_dem")
+    return DEM(fn_ref), DEM(fn_tba)
+
+
+class TestUncertaintyNotebook:
+
+    def test_precision_of_other_sqrt2(self) -> None:
+        """precision_of_other='same' divides the inferred error by sqrt(2) vs 'finer' (Eq. 7-8)."""
+        pytest.importorskip("skgstat")
+        warnings.filterwarnings("ignore", category=UserWarning)
+        dem_ref, dem_tba = _load_dems()
+
+        het_finer, _ = _infer_uncertainty(dem_ref, dem_tba, precision_of_other="finer", random_state=SEED)
+        het_same, _ = _infer_uncertainty(dem_ref, dem_tba, precision_of_other="same", random_state=SEED)
+
+        sig_finer = _finite_array(het_finer[0])
+        sig_same = _finite_array(het_same[0])
+
+        m = np.isfinite(sig_finer) & np.isfinite(sig_same)
+        assert m.sum() > 0
+        # Same random_state -> identical binning/fit, so the only difference is the sqrt(2) scaling.
+        np.testing.assert_allclose(sig_same[m], sig_finer[m] / np.sqrt(2), rtol=1e-5)
+
+    def test_precision_of_other_invalid_raises(self) -> None:
+        """An unsupported precision (e.g. a coarser 'worse' other) raises instead of silently acting like 'finer'."""
+        pytest.importorskip("skgstat")
+        dem_ref, dem_tba = _load_dems()
+        with pytest.raises(ValueError, match="precision_of_other"):
+            _infer_uncertainty(dem_ref, dem_tba, precision_of_other="worse")  # type: ignore[arg-type]
+
+    def test_precoreg_equivalence(self) -> None:
+        """precoreg=True equals a manual fit->apply->propagate(precoreg=False) with a matched RNG stream."""
+        pytest.importorskip("skgstat")
+        warnings.filterwarnings("ignore", category=UserWarning)
+        dem_ref, dem_tba = _load_dems()
+        method = coreg.LZD()
+        nsim = 5
+
+        # Auto: precoreg performs the initial fit+apply internally, consuming the shared rng first.
+        auto = _propag_uncertainty_coreg(
+            reference_elev=dem_ref,
+            to_be_aligned_elev=dem_tba,
+            coreg_method=method,
+            nsim=nsim,
+            error_applied_to="ref",
+            precoreg=True,
+            random_state=SEED,
+        )[0]
+
+        # Manual mirror: advance an rng with the SAME initial fit + apply, then propagate with
+        # precoreg=False passing the *advanced* generator so the random stream continues identically.
+        rng = np.random.default_rng(SEED)
+        c0 = method.copy()
+        c0.fit(reference_elev=dem_ref, to_be_aligned_elev=dem_tba, inlier_mask=None, random_state=rng)
+        dem_tba_align = c0.apply(dem_tba)
+        manual = _propag_uncertainty_coreg(
+            reference_elev=dem_ref,
+            to_be_aligned_elev=dem_tba_align,
+            coreg_method=method,
+            nsim=nsim,
+            error_applied_to="ref",
+            precoreg=False,
+            random_state=rng,
+        )[0]
+
+        pd.testing.assert_frame_equal(auto, manual, check_exact=False, rtol=1e-6, atol=1e-6)
+
+    def test_precoreg_deterministic(self) -> None:
+        """Two precoreg=True runs with the same seed give identical reports."""
+        pytest.importorskip("skgstat")
+        warnings.filterwarnings("ignore", category=UserWarning)
+        dem_ref, dem_tba = _load_dems()
+        method = coreg.NuthKaab()
+        nsim = 4
+
+        kw = dict(
+            reference_elev=dem_ref,
+            to_be_aligned_elev=dem_tba,
+            coreg_method=method,
+            nsim=nsim,
+            error_applied_to="tba",
+            precoreg=True,
+            random_state=123,
+        )
+        r1 = _propag_uncertainty_coreg(**kw)[0]
+        r2 = _propag_uncertainty_coreg(**kw)[0]
+        pd.testing.assert_frame_equal(r1, r2, check_exact=False, rtol=0, atol=0)
+
+    def test_diverged_simulation_is_skipped(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: Any,
+        assert_and_allow_log: Callable[..., None],
+    ) -> None:
+        """A simulation whose coregistration fails to converge is skipped (with a warning) rather than
+        aborting the whole Monte Carlo run; the remaining simulations still yield a finite report.
+
+        A real divergence (e.g. NuthKaab exhausting its subsample on a small/pre-aligned extent) is
+        numerics- and version-dependent, so the failure is forced deterministically here instead.
+        """
+        pytest.importorskip("skgstat")
+        warnings.filterwarnings("ignore", category=UserWarning)
+        dem_ref, dem_tba = _load_dems()
+
+        # Make exactly one simulation's coregistration raise, independent of platform/library versions.
+        original_fit = coreg.NuthKaab.fit
+        state = {"n": 0}
+
+        def flaky_fit(self: coreg.NuthKaab, *args: object, **kwargs: object) -> object:
+            state["n"] += 1
+            if state["n"] == 2:
+                raise ValueError("forced non-convergence for test")
+            return original_fit(self, *args, **kwargs)
+
+        monkeypatch.setattr(coreg.NuthKaab, "fit", flaky_fit)
+
+        with caplog.at_level(logging.WARNING):
+            summary = _propag_uncertainty_coreg(
+                reference_elev=dem_ref,
+                to_be_aligned_elev=dem_tba,
+                coreg_method=coreg.NuthKaab(),
+                nsim=4,
+                error_applied_to="tba",
+                precoreg=False,
+                random_state=SEED,
+            )[0]
+
+        # The skip is expected: confirm it was logged (and allow it past the global log-warning collector).
+        assert_and_allow_log(caplog, level=logging.WARNING, match="skipped")
+        for k in ("tx", "ty", "tz"):
+            assert np.isfinite(summary.loc[k, "std"])
+
+    def test_variogram_plotting_invariant(self) -> None:
+        """Fitted variogram (rises 0->sill) and correlation (falls 1->0) satisfy gamma = sill*(1 - rho).
+
+        This is the hack-free basis for plotting the empirical + fitted variogram together:
+        ``plot_variogram(corr_out[0], [xdem.spatialstats.get_variogram_model_func(corr_out[1])])``.
+        """
+        pytest.importorskip("skgstat")
+        warnings.filterwarnings("ignore", category=UserWarning)
+        dem_ref, dem_tba = _load_dems()
+
+        _, corr_out = _infer_uncertainty(dem_ref, dem_tba, random_state=SEED)
+        df_emp, params, corr_func = corr_out
+
+        # Reconstruct the variogram model function from the already-public helper (the correct input for
+        # plot_variogram, which expects a variogram rather than the returned correlation function).
+        vario_func = xdem.spatialstats.get_variogram_model_func(params)
+        total_sill = float(params["psill"].sum())
+        assert total_sill > 0
+        max_range = float(params["range"].max())
+
+        h = np.array([0.0, max_range, 5.0 * max_range])
+        rho = np.asarray(corr_func(h), dtype=float)
+        gamma = np.asarray(vario_func(h), dtype=float)
+
+        # Correlation starts at 1 and decays to ~0; variogram starts at 0 and rises to ~sill.
+        np.testing.assert_allclose(rho[0], 1.0, atol=1e-6)
+        np.testing.assert_allclose(gamma[0], 0.0, atol=1e-9 + 1e-6 * total_sill)
+        assert rho[-1] < 1e-2
+        np.testing.assert_allclose(gamma[-1], total_sill, rtol=1e-2)
+
+        # Exact invariant linking the two representations (what makes the plot render correctly).
+        np.testing.assert_allclose(gamma, total_sill * (1.0 - rho), rtol=1e-9, atol=1e-12)

--- a/xdem/uncertainty/uncertainty.py
+++ b/xdem/uncertainty/uncertainty.py
@@ -81,6 +81,7 @@ def _propag_uncertainty_coreg(
     coreg_method: coreg.Coreg,
     nsim: int = 30,
     error_applied_to: Literal["ref", "tba"] = "tba",
+    precoreg: bool = False,
     inlier_mask: Raster | NDArrayb = None,
     random_state: int | np.random.Generator | None = None,
     kwargs_coreg_fit: dict[str, Any] | None = None,
@@ -96,6 +97,10 @@ def _propag_uncertainty_coreg(
     :param to_be_aligned_elev: To-be-aligned elevation.
     :param coreg_method: Coregistration method.
     :param nsim: Number of simulations to perform.
+    :param error_applied_to: Which input the simulated error field is applied to ("ref" or "tba").
+    :param precoreg: If True, co-register once before inferring the error structure, so it is estimated
+        on the aligned residual rather than the raw (mis-aligned) inputs; the reported mean transform is
+        then the residual (~0). Requires an affine method. Defaults to False (previous behaviour).
     :param inlier_mask: Inlier mask (valid = True).
     :param random_state: Random state.
     :param kwargs_coreg_fit: Keyword arguments passed to `Coreg.fit`.
@@ -110,6 +115,20 @@ def _propag_uncertainty_coreg(
 
     # Define random state
     rng = np.random.default_rng(random_state)
+
+    # Optionally co-register once before inferring the error structure, so it is estimated on the aligned
+    # residual rather than the raw inputs (single pass; affine methods only).
+    if precoreg:
+        logging.info("Pre-coregistering inputs before inferring uncertainty...")
+        c_init = coreg_method.copy()
+        c_init.fit(
+            reference_elev=reference_elev,
+            to_be_aligned_elev=to_be_aligned_elev,
+            inlier_mask=inlier_mask,
+            random_state=rng,
+            **kwargs_coreg_fit,
+        )
+        to_be_aligned_elev = c_init.apply(to_be_aligned_elev)
 
     # First, infer uncertainty
     if error_applied_to == "ref":
@@ -146,15 +165,30 @@ def _propag_uncertainty_coreg(
             ref_elev = reference_elev
             tba_elev = to_be_aligned_elev + error_field
 
-        # Run coreg fit
+        # A simulation can occasionally fail to converge; skip it with a warning rather than aborting.
         logging.info(f"  Running coregistration fit...")
         c = coreg_method.copy()  # Avoid carrying over the state over multiple simulations
-        c.fit(reference_elev=ref_elev, to_be_aligned_elev=tba_elev, inlier_mask=inlier_mask, random_state=rng,
-              **kwargs_coreg_fit)
+        try:
+            c.fit(reference_elev=ref_elev, to_be_aligned_elev=tba_elev, inlier_mask=inlier_mask, random_state=rng,
+                  **kwargs_coreg_fit)
+        except Exception as err:
+            logging.warning(f"  Simulation {i+1} of {nsim} failed to converge and was skipped: {err}")
+            continue
         df_it = _postproc_coreg_metadata(c)
         df_it["nsim"] = i + 1
         list_df.append(df_it)
         list_coreg.append(c)
+
+    # Require at least two successful simulations to estimate a standard deviation
+    if len(list_df) < 2:
+        raise RuntimeError(
+            f"Only {len(list_df)} of {nsim} simulations succeeded; cannot estimate uncertainty "
+            "(coregistration repeatedly failed to converge). Try a larger subsample or extent, or a "
+            "more robust method."
+        )
+    if len(list_df) < nsim:
+        logging.warning(f"{nsim - len(list_df)} of {nsim} simulations were skipped after failing to "
+                        f"converge; uncertainty estimated from {len(list_df)} simulations.")
 
     # Finally, estimate errors for all the translations/rotations in the simulations
     df = pd.concat(list_df, ignore_index=True)
@@ -313,20 +347,19 @@ def _infer_uncertainty(
              Tuple of (Empirical variogram dataframe, Model parameters dataframe, Spatial error correlation function).
     """
 
+    # Validate the precision assumption: only 'finer' or 'same' are invertible from the difference alone.
+    if precision_of_other not in ("finer", "same"):
+        raise ValueError(
+            f"`precision_of_other` must be 'finer' or 'same', got {precision_of_other!r}. A coarser "
+            "dataset is not supported; pass the less precise dataset as `source_elev` instead."
+        )
+
     # Summarize approach steps
     approach_dict = {
         "H2022": {"heterosc": True, "multi_range": True},
         "R2009": {"heterosc": False, "multi_range": True},
         "Basic": {"heterosc": False, "multi_range": False},
     }
-
-    # # Difference the two datasets
-    # dh = _difference(source_elev, other_elev)
-
-    # # If the precision of the other Raster is the same, divide the dh values by sqrt(2)
-    # # See Equation 7 and 8 of Hugonnet et al. (2022)
-    # if precision_of_other == "same":
-    #     dh = dh / np.sqrt(2)
 
     logging.info(f"Starting heteroscedasticity inference.")
     # Heteroscedasticity
@@ -339,6 +372,7 @@ def _infer_uncertainty(
         z_name=z_name,
         subsample_hetesc=subsample_hetesc,
         spread_statistic=spread_estimator,
+        precision_of_other=precision_of_other,
     )
 
     logging.info(f"Starting spatial correlation inference.")
@@ -349,6 +383,7 @@ def _infer_uncertainty(
         inlier_mask=stable_terrain,
         errors=sig_dh,
         estimator=variogram_estimator,
+        precision_of_other=precision_of_other,
         random_state=random_state,
         list_models=vario_model,
         subsample=subsample_pairs_vario,
@@ -367,6 +402,8 @@ def _infer_heteroscedasticity(
     vector_mask_mode: Literal["inside", "outside"] = "inside",
     # Whether to infer a variable error (default) or constant
     heterosc: bool = True,
+    # Precision of the other dataset relative to the source (Hugonnet 2022, Eq. 7-8)
+    precision_of_other: Literal["finer", "same"] = "finer",
     # Heteroscedastic predictors
     hetesc_vars: (
         tuple[Raster | np.ndarray | str, ...]
@@ -451,6 +488,11 @@ def _infer_heteroscedasticity(
 
     # Elevation difference of the subsample
     dvalues_fit = rp1_fit - rp2_fit
+
+    # Same-precision inputs double-count error in the difference (var(dh) = 2*sigma^2); divide by sqrt(2)
+    # to recover the single-dataset error (Hugonnet 2022, Eq. 7-8), before binning so both paths get it.
+    if precision_of_other == "same":
+        dvalues_fit = dvalues_fit / np.sqrt(2)
 
     # 3) Perform binning and function fit on array inputs
 
@@ -583,6 +625,7 @@ def _infer_spatial_correlation(
     vector_mask_mode: Literal["inside", "outside"] = "inside",
     errors: NDArrayf | Raster | None = None,
     estimator: Literal["matheron", "cressie", "genton", "dowd"] = "dowd",
+    precision_of_other: Literal["finer", "same"] = "finer",
     sampling: Literal["loglag", "random_xy"] = "loglag",
     subsample: int | float = 1,
     random_state: int | np.random.Generator | None = None,
@@ -654,6 +697,10 @@ def _infer_spatial_correlation(
     # Difference and standardize
     logging.info(f"  Step 2: Standardizing elevation differences...")
     dh_vals = rp1 - rp2
+    # Same-precision correction (Hugonnet 2022, Eq. 7-8), matching the heteroscedasticity step; the
+    # correlation function is scale-invariant, so this only affects the reported variogram magnitude.
+    if precision_of_other == "same":
+        dh_vals = dh_vals / np.sqrt(2)
     if errors is not None:
         dh_vals = dh_vals / aux_e["err"]
 


### PR DESCRIPTION
Fixes and tests for elevation-uncertainty propagation (the `uncertainty` module), building on #759.
These came out of testing `_propag_uncertainty_coreg` / `_infer_uncertainty` on the Longyearbyen sample
DEMs and on 0.5 m data. Defaults are unchanged throughout, so existing results are bit-identical unless
the new options are used.

### Changes

1. **`precision_of_other="same"` was a no-op.** The √2 "same precision" correction (Hugonnet et al.,
   2022, Eq. 7-8) was commented out in `_infer_uncertainty` and never threaded down, so for two datasets
   of similar precision (e.g. DEM–DEM) the inferred per-pixel error was ~√2 too large, inflating the
   propagated translation uncertainty. Re-enabled in the heteroscedasticity step (matching the legacy
   `dem.py` path). Default `"finer"` is unchanged; an unsupported value now raises instead of silently
   behaving like `"finer"`.

2. **Error structure was inferred from un-coregistered inputs.** `_propag_uncertainty_coreg` ran
   `_infer_uncertainty` once on the raw inputs, conflating true error with the misalignment/terrain
   (and, in the test case, glacier-change) signal. Added an **opt-in** `precoreg` flag: when `True`,
   co-register once, then infer the error structure and simulate on the aligned residual (this automates
   the manual fit→apply→propagate workaround). With `precoreg=True`, `summary["mean"]` becomes the
   residual transform (≈0), which is documented. Default `precoreg=False` preserves current behaviour.
   (Kept opt-in because `apply`'s edge regridding can make NuthKaab diverge on very small extents.)

3. **Variogram plotting.** `_infer_uncertainty` returns the *correlation* function, which renders
   incorrectly when passed to `plot_variogram` (which expects a *variogram*). No code change is needed —
   the variogram is reconstructible from the already-public `get_variogram_model_func(params)`. Added a
   test of the `γ(h) = sill·(1 − ρ(h))` invariant that underpins the correct plotting recipe.

4. **Monte Carlo robustness.** A single non-converging simulation aborted the whole run. Diverged
   simulations are now skipped with a warning, with a guard that requires a minimum number of successful
   simulations before reporting.

### Tests
`tests/test_uncertainty/test_uncertainty_notebook.py` (cropped sample data, small `nsim`): √2 scaling,
invalid `precision_of_other` raises, precoreg equivalence + determinism, diverged-sim skip, and the
variogram-plotting invariant.

### Notes
No public API change: `_propag_uncertainty_coreg` is private and `precision_of_other` was already
documented; `precoreg` / `error_applied_to` docstrings added.

*Disclosure: prepared with AI assistance (Claude). I have reviewed and understand all changes and take
responsibility for them.*
